### PR TITLE
fix: log OMNI distillation failures at DEBUG level in transform_terminal_output hook

### DIFF
--- a/src/hermes_omni_signal_engine/plugin.py
+++ b/src/hermes_omni_signal_engine/plugin.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import asdict
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from .config import config_path, load_config, save_config, default_config
 from .runner import (
@@ -214,6 +217,8 @@ def _transform_terminal_output(*, command: str, output: str, returncode: int = 0
     if not output:
         return None
     result = distill_text(output, command or "terminal", cfg)
+    if not result.ok:
+        logger.debug("OMNI distillation failed (omni_exit=%s): %s", result.returncode, result.error)
     if not result.stdout or result.stdout == output:
         return None
     header = "[OMNI distilled terminal output"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -45,6 +45,21 @@ def test_transform_terminal_output_distills_when_enabled(monkeypatch):
     assert out == "[OMNI distilled terminal output]\ndistilled"
 
 
+def test_transform_terminal_output_returns_none_and_logs_on_distill_failure(monkeypatch, caplog):
+    cfg = PluginConfig(enable_transform_terminal_output=True)
+    monkeypatch.setattr(plugin, "load_config", lambda: cfg)
+    # OMNI fails: returncode=1, error="omni internal error", stdout unchanged
+    monkeypatch.setattr(
+        plugin, "distill_text",
+        lambda output, command, cfg: RunResult(False, 1, output, "omni internal error", ["omni"], error="omni internal error"),
+    )
+    with caplog.at_level("DEBUG", logger="hermes_omni_signal_engine.plugin"):
+        out = plugin._transform_terminal_output(command="pytest", output="raw", returncode=0)
+    assert out is None
+    assert "OMNI distillation failed" in caplog.text
+    assert "omni_exit=1" in caplog.text
+
+
 def test_tool_compress_requires_text(monkeypatch):
     result = json.loads(plugin._tool_compress({}))
     assert result["ok"] is False


### PR DESCRIPTION
## Summary

`_transform_terminal_output` silently returns `None` when OMNI distillation fails (non-zero exit code or error message) without any diagnostic trace. This makes it difficult to debug situations where the plugin is active but not producing distilled output. This PR adds a `DEBUG`-level log entry recording the failure before returning `None`.

**Tests:** 14/14 pass (13 existing + 1 new).

---

## Changes

### `src/hermes_omni_signal_engine/plugin.py`

**Before:**
```python
result = distill_text(output, command or "terminal", cfg)
if not result.stdout or result.stdout == output:
    return None
```

**After:**
```python
result = distill_text(output, command or "terminal", cfg)
if not result.ok:
    logger.debug("OMNI distillation failed (omni_exit=%s): %s", result.returncode, result.error)
if not result.stdout or result.stdout == output:
    return None
```

- Added `import logging` and `logger = logging.getLogger(__name__)`
- Added `DEBUG`-level log when OMNI returns `ok=False`, recording exit code and error string
- Log is at `DEBUG` level (not `INFO`/`WARNING`) so it does not noise normal operation; enable `DEBUG` logging on the `hermes_omni_signal_engine.plugin` logger to diagnose issues

### `tests/test_plugin.py`

Added `test_transform_terminal_output_returns_none_and_logs_on_distill_failure` — verifies that when `distill_text` returns `ok=False` with an unchanged stdout, the hook returns `None` and the debug log contains the failure message with exit code.

---

## What Was Not Changed

- **Windows path** (`runner.py:120-123`): The `platform.system().lower().startswith("win")` branch correctly uses `["cmd", "/C", command]` and the `else` branch uses `["/bin/sh", "-c", command]`. The code is correct as-is.
- **`transform_terminal_output` returncode handling**: The hook currently distills output regardless of `returncode`. This is intentional — failed commands can still produce noisy output worth distilling. No change proposed.
- **`pre_tool_call` hook**: This plugin does not register a command-rewrite hook. There is no conflict with hermes-rtk-optimizer on that layer.
